### PR TITLE
Temporary fix for LAB_RESULT_CM

### DIFF
--- a/Oracle/PCORNetLoader_ora.sql
+++ b/Oracle/PCORNetLoader_ora.sql
@@ -1280,6 +1280,7 @@ to_char(m.end_date,'HH:MI') RESULT_TIME,
 CASE WHEN m.ValType_Cd='N' THEN m.NVAL_NUM ELSE null END RESULT_NUM,
 CASE WHEN m.ValType_Cd='N' THEN (CASE NVL(nullif(m.TVal_Char,''),'NI') WHEN 'E' THEN 'EQ' WHEN 'NE' THEN 'OT' WHEN 'L' THEN 'LT' WHEN 'LE' THEN 'LE' WHEN 'G' THEN 'GT' WHEN 'GE' THEN 'GE' ELSE 'NI' END)  ELSE 'TX' END RESULT_MODIFIER,
 NVL(m.Units_CD,'NI') RESULT_UNIT, -- TODO: Should be standardized units
+'NI' RESULT_UNIT, -- Temporary fix for KUMC
 nullif(norm.NORM_RANGE_LOW,'') NORM_RANGE_LOW
 ,norm.NORM_MODIFIER_LOW,
 nullif(norm.NORM_RANGE_HIGH,'') NORM_RANGE_HIGH

--- a/Oracle/PCORNetLoader_ora.sql
+++ b/Oracle/PCORNetLoader_ora.sql
@@ -1279,7 +1279,7 @@ to_char(m.end_date,'HH:MI') RESULT_TIME,
 'NI' RESULT_QUAL, -- Temporary fix for KUMC
 CASE WHEN m.ValType_Cd='N' THEN m.NVAL_NUM ELSE null END RESULT_NUM,
 CASE WHEN m.ValType_Cd='N' THEN (CASE NVL(nullif(m.TVal_Char,''),'NI') WHEN 'E' THEN 'EQ' WHEN 'NE' THEN 'OT' WHEN 'L' THEN 'LT' WHEN 'LE' THEN 'LE' WHEN 'G' THEN 'GT' WHEN 'GE' THEN 'GE' ELSE 'NI' END)  ELSE 'TX' END RESULT_MODIFIER,
-NVL(m.Units_CD,'NI') RESULT_UNIT, -- TODO: Should be standardized units
+--NVL(m.Units_CD,'NI') RESULT_UNIT, -- TODO: Should be standardized units
 'NI' RESULT_UNIT, -- Temporary fix for KUMC
 nullif(norm.NORM_RANGE_LOW,'') NORM_RANGE_LOW
 ,norm.NORM_MODIFIER_LOW,


### PR DESCRIPTION
A temporary fix for the `RESULT_UNIT` line of the `LAB_RESULT_CM` transform.  Follow [GPC issue #285](https://informatics.gpcnetwork.org/trac/Project/ticket/285#comment:15) for details on the development of a more permanent solution.
