### PR TITLE
don't exclude EI, UHC when looking for PDX=P

### DIFF
--- a/Oracle/PCORNetLoader_ora.sql
+++ b/Oracle/PCORNetLoader_ora.sql
@@ -1051,7 +1051,7 @@ select distinct factline.patient_num, factline.encounter_num encounterid,	enc_ty
                                                       else '09'
        end dxtype,
 	CASE WHEN enc_type='AV' THEN 'FI' ELSE nvl(SUBSTR(dxsource,INSTR(dxsource,':')+1,2) ,'NI') END dx_source,
-	CASE WHEN enc_type in ('IP', 'IS')  -- PDX is "relevant only on IP and IS encounters"
+	CASE WHEN enc_type in ('EI', 'IP', 'IS')  -- PDX is "relevant only on IP and IS encounters"
              THEN nvl(SUBSTR(pdxsource,INSTR(pdxsource, ':')+1,2),'NI')
              ELSE 'X' END PDX
 from i2b2fact factline

--- a/Oracle/pcornet_mapping.csv
+++ b/Oracle/pcornet_mapping.csv
@@ -7,6 +7,7 @@ pcori_path,local_path
 \PCORI_MOD\RX_BASIS\PR\01\,\Medication\Outpatient\
 \PCORI_MOD\RX_BASIS\PR\02\,\Medication\PRN Inpatient Order\
 \PCORI_MOD\PDX\P\,\Diagnosis\\modifier_dx\billing_diagnosis\discharge\discharge_primary\
+\PCORI_MOD\PDX\P\,\Diagnosis\Billing\Primary\
 \PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\DI\,\Diagnosis\\modifier_dx\billing_diagnosis\discharge\
 \PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\AD\,\Diagnosis\\modifier_dx\billing_diagnosis\admit\
 "\PCORI_MOD\CONDITION_OR_DX\DX_SOURCE\UN\","\Diagnosis\Billing\UHC_DIAGNOSIS\"


### PR DESCRIPTION
Though the CDM spec says "Relevant only on IP and IS encounters," table
Table IVE. Principal Diagnoses for Institutional Encounters of the EDC
report includes a row for EI as well.

We raised https://github.com/CDMFORUM/CDM-ERRATA/issues/19 about this.

Meanwhile, we have been counting only Epic billing diagnoses as
discharge diagnoses when looking for PDX. The
`\Diagnosis\Billing\Primary\` modifier used in UHC should be counted as
well. This modifier is also used in IDX, which will raise our count of
"For ED, AV, and OA encounter types, mark as X=Unable to Classify." but
that seems worthwhile.