### PR TITLE
add pcornet_init dependency to pcornet_loader to clear cdm_status

### DIFF
--- a/i2p_tasks.py
+++ b/i2p_tasks.py
@@ -222,7 +222,7 @@ class pcornet_loader(I2PScriptTask):
     script = Script.pcornet_loader
 
     def requires(self) -> List[luigi.Task]:
-        return [harvest()]
+        return [pcornet_init(), harvest()]
 
 
 class pcornet_trial(I2PScriptTask):


### PR DESCRIPTION
not sure if we indeed want `pcornet_init` to run in every instance of `pcornet_loader`, but it promises to clear the `cdm_status` which i need for COVID cdm